### PR TITLE
DEVREL-2669: Examples for new ways of creating components

### DIFF
--- a/src/components/PermissionsMap.tsx
+++ b/src/components/PermissionsMap.tsx
@@ -50,6 +50,8 @@ export const permissionsMap: PermissionsMap = {
     getRootElement: { permissions: ['canAccessCanvas'] },
     registerComponent: { permissions: ['canCreateComponents'] },
     createComponentWithoutRoot: { permissions: ['canCreateComponents'] },
+    createComponentFromElement: { permissions: ['canCreateComponents'] },
+    duplicateComponent: { permissions: ['canCreateComponents'] },
     unregisterComponent: { permissions: ['canCreateComponents'] },
     getAllComponents: { permissions: ['canAccessCanvas'] },
     getComponentByName: { permissions: ['canAccessCanvas'] },

--- a/src/components/PermissionsMap.tsx
+++ b/src/components/PermissionsMap.tsx
@@ -49,6 +49,7 @@ export const permissionsMap: PermissionsMap = {
     setName: { permissions: ['canModifyComponents'] },
     getRootElement: { permissions: ['canAccessCanvas'] },
     registerComponent: { permissions: ['canCreateComponents'] },
+    createComponentWithoutRoot: { permissions: ['canCreateComponents'] },
     unregisterComponent: { permissions: ['canCreateComponents'] },
     getAllComponents: { permissions: ['canAccessCanvas'] },
     getComponentByName: { permissions: ['canAccessCanvas'] },

--- a/src/designer-extension-typings/api.d.ts
+++ b/src/designer-extension-typings/api.d.ts
@@ -134,6 +134,31 @@ interface SharedApi {
     name: string,
     root: AnyElement | ElementPreset<AnyElement> | Component
   ): Promise<Component>;
+
+  /**
+   * Create a component that is not inside any element.
+   * @param options - The options for the component
+   * @param options.name - The name of the component (required)
+   * @param options.group - The group/folder to place the component in (optional)
+   * @param options.description - A description for the component (optional)
+   * @returns A Promise resolving to an object containing the newly created Component - with the id property.
+   * @example
+   * ```ts
+   * // Create a hero component in the Sections group that is not within an existing element
+   * const hero = await webflow.registerComponent({
+   *   name: 'Hero Section',
+   *   group: 'Sections',
+   *   description: 'A reusable hero section with heading and CTA',
+   * });
+   *
+   * // Example Response
+   * {id: '204d04de-bf48-5b5b-0ca8-6ec4c5364fd2'}
+   * ```
+   */
+  createComponentWithoutRoot(
+    options: ComponentOptions
+  ): Promise<Component>;
+
   /**
    * Create a blank component.
    * @param options - Options for creating the blank component.

--- a/src/designer-extension-typings/api.d.ts
+++ b/src/designer-extension-typings/api.d.ts
@@ -132,31 +132,31 @@ interface SharedApi {
    */
   registerComponent(
     name: string,
-    root: AnyElement | ElementPreset<AnyElement> | Component
+    root?: AnyElement | ElementPreset<AnyElement> | Component | ComponentId
   ): Promise<Component>;
 
   /**
-   * Create a component that is not inside any element.
-   * @param options - The options for the component
-   * @param options.name - The name of the component (required)
-   * @param options.group - The group/folder to place the component in (optional)
-   * @param options.description - A description for the component (optional)
+   * Create a component by converting an element into a component or duplicating a component.
+   * @param options - The options for the new component.
+   * @param root - An Element that will become the Root Element of the Component.
    * @returns A Promise resolving to an object containing the newly created Component - with the id property.
    * @example
    * ```ts
-   * // Create a hero component in the Sections group that is not within an existing element
-   * const hero = await webflow.registerComponent({
-   *   name: 'Hero Section',
-   *   group: 'Sections',
-   *   description: 'A reusable hero section with heading and CTA',
-   * });
-   *
-   * // Example Response
-   * {id: '204d04de-bf48-5b5b-0ca8-6ec4c5364fd2'}
+   * // Convert an existing element into a component
+   * const selectedElement = await webflow.getSelectedElement()
+   * const heroComponent = await webflow.registerComponent(
+   *   {
+   *     name: 'Hero Section',
+   *     group: 'Sections',
+   *     description: 'Main hero with heading and CTA'
+   *   },
+   *   selectedElement
+   * )
    * ```
    */
-  createComponentWithoutRoot(
-    options: ComponentOptions
+  registerComponent(
+    options: ComponentOptions,
+    root?: AnyElement | ElementPreset<AnyElement> | Component | ComponentId
   ): Promise<Component>;
 
   /**

--- a/src/examples/components.ts
+++ b/src/examples/components.ts
@@ -193,7 +193,7 @@ export const Components = {
   },
 
   createComponentFromElement: async () => {
-    // Convert an existing element into a component
+    // Convert an existing element into a component, by default replacing the element with the new component
     const selectedElement = await webflow.getSelectedElement()
     if (selectedElement) {
       const heroComponent = await webflow.registerComponent(

--- a/src/examples/components.ts
+++ b/src/examples/components.ts
@@ -182,6 +182,16 @@ export const Components = {
     }
   },
 
+  createComponentWithoutRoot: async () => {
+    // Create a hero component in the Sections group that is not within an existing element
+    const hero = await webflow.registerComponent({
+      name: 'Hero Section',
+      group: 'Sections',
+      description: 'A reusable hero section with heading and CTA',
+    });
+    console.log(`Component registered with ID: ${hero.id}`)
+  },
+
   deleteComponent: async () => {
     // Get selected element
     const selectedElement = await webflow.getSelectedElement()

--- a/src/examples/components.ts
+++ b/src/examples/components.ts
@@ -192,6 +192,27 @@ export const Components = {
     console.log(`Component registered with ID: ${hero.id}`)
   },
 
+  createComponentFromElement: async () => {
+    // Convert an existing element into a component
+    const selectedElement = await webflow.getSelectedElement()
+    if (selectedElement) {
+      const heroComponent = await webflow.registerComponent(
+        {
+          name: 'Hero Section',
+          group: 'Sections',
+          description: 'Main hero with heading and CTA'
+        },
+        selectedElement
+      )
+    }
+  },
+
+  duplicateComponent: async () => {
+    // Duplicate a component
+    const [original] = await webflow.getAllComponents()
+    const copy = await webflow.registerComponent({ name: 'Card Copy' }, original)
+  },
+
   deleteComponent: async () => {
     // Get selected element
     const selectedElement = await webflow.getSelectedElement()


### PR DESCRIPTION
Examples for https://github.com/webflow/openapi-internal/pull/708 and https://github.com/webflow/openapi-internal/pull/716. Also removes deprecated syntax.

Not sure if this is working right. When I go into the styles section of the tester app I can put in params and then click run. When I set that up with these examples, it runs them immediately, before I have the opportunity to put in a parameter. Seems to be a problem for all of the examples in the components section.
