### PR TITLE
DEVREL-2801: Copy to playground button

### DIFF
--- a/src/components/APIExplorer.tsx
+++ b/src/components/APIExplorer.tsx
@@ -41,6 +41,7 @@ interface APIExplorerProps {
   setSelectedExampleCategory: (value: string) => void
   selectedFunctionName: string
   setSelectedFunctionName: (value: string) => void
+  onCopyToPlayground: (code: string) => void
 }
 
 const APIExplorer: React.FC<APIExplorerProps> = ({
@@ -48,6 +49,7 @@ const APIExplorer: React.FC<APIExplorerProps> = ({
   setSelectedExampleCategory,
   selectedFunctionName,
   setSelectedFunctionName,
+  onCopyToPlayground,
 }) => {
   const [functionParameters, setFunctionParameters] = useState<ParameterMap>({})
   const [apiOutput, setApiOutput] = useState('')
@@ -323,6 +325,14 @@ const APIExplorer: React.FC<APIExplorerProps> = ({
           >
             Run
           </button>
+          {functionCode && (
+            <button
+              className="button cc-primary"
+              onClick={() => onCopyToPlayground(functionCode)}
+            >
+              Copy to playground
+            </button>
+          )}
         </div>
       )}
       {functionCode && (

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -42,8 +42,12 @@ const styleProperties = await primaryStyle.getProperties();
 console.log(styleProperties);
 `
 
-const Playground: React.FC = () => {
-  const [code, setCode] = useState(defaultCode)
+interface PlaygroundProps {
+  initialCode?: string | null
+}
+
+const Playground: React.FC<PlaygroundProps> = ({ initialCode }) => {
+  const [code, setCode] = useState(initialCode ?? defaultCode)
   const [output, setOutput] = useState('')
   const [isRunning, setIsRunning] = useState(false)
   const [isCopied, setIsCopied] = useState(false)
@@ -53,6 +57,13 @@ const Playground: React.FC = () => {
   const monaco = useMonaco()
   const editorRef = useRef<any>(null)
   const codeRef = useRef(code)
+
+  useEffect(() => {
+    if (initialCode != null) {
+      setCode(initialCode)
+      codeRef.current = initialCode
+    }
+  }, [initialCode])
   const isMountedRef = useRef(true)
 
   // Cleanup on unmount

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -62,6 +62,9 @@ const Playground: React.FC<PlaygroundProps> = ({ initialCode }) => {
     if (initialCode != null) {
       setCode(initialCode)
       codeRef.current = initialCode
+      if (editorRef.current) {
+        editorRef.current.setValue(initialCode)
+      }
     }
   }, [initialCode])
   const isMountedRef = useRef(true)
@@ -412,6 +415,9 @@ const Playground: React.FC<PlaygroundProps> = ({ initialCode }) => {
           onMount={(editor, monaco) => {
             try {
               editorRef.current = editor
+              // Force editor content to match current code, in case Monaco reuses
+              // a cached model for the same path with stale content
+              editor.setValue(codeRef.current)
               if (monaco && isMountedRef.current) {
                 editor.addCommand(
                   monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -31,6 +31,7 @@ const App = () => {
   const [activeTab, setActiveTab] = useState('api')
   const [selectedExampleCategory, setSelectedExampleCategory] = useState('')
   const [selectedFunctionName, setSelectedFunctionName] = useState('')
+  const [playgroundCode, setPlaygroundCode] = useState(null)
   const containerRef = useRef(null)
   const hasInitializedRef = useRef(false)
 
@@ -167,9 +168,13 @@ const App = () => {
           setSelectedExampleCategory={setSelectedExampleCategory}
           selectedFunctionName={selectedFunctionName}
           setSelectedFunctionName={setSelectedFunctionName}
+          onCopyToPlayground={(code) => {
+            setPlaygroundCode(code)
+            setActiveTab('code')
+          }}
         />
       )}
-      {activeTab === 'code' && <Playground />}
+      {activeTab === 'code' && <Playground initialCode={playgroundCode} />}
       <footer className="wf-footer">
         <img
           src="https://dhygzobemt712.cloudfront.net/Mark/Mark_Logo_Blue.svg"


### PR DESCRIPTION
We have examples on the API Explorer tab and you can run them with the new Run button, but in many cases the example from the docs may not be exactly what you want to do. So this PR adds a "Copy to playground" button that copies the code to the playground tab where you can edit and run it.

Possible dangers: The Copy to playground button overwrites any code that was in there, so you may lose something. We could throw a warning or just add to the end of the existing code?

<img width="491" height="276" alt="Screenshot 2026-04-14 at 8 29 39 AM" src="https://github.com/user-attachments/assets/4667a2de-a1f1-430c-802b-17c430df5067" />


Really we need better examples in here that will run regardless of what's going on on the canvas instead of assuming  the names of things. I also notice that in some cases the containing function is shown in the examples.