### PR TITLE
DEVREL-2692: Branch navigation examples

### DIFF
--- a/src/examples/pages.ts
+++ b/src/examples/pages.ts
@@ -475,4 +475,43 @@ export const Pages = {
       },
     },
   },
+
+  // Page Branching
+  pageBranching: {
+    getBranchId: {
+      displayName: 'Get branch ID',
+      code: async () => {
+        // Get Current Page
+        const currentPage = (await webflow.getCurrentPage()) as Page
+
+        // Get branch ID
+        const branchId = await currentPage.getBranchId()
+        console.log(branchId)
+      }
+    },
+
+    getParentPageId: {
+      displayName: 'Get parent page ID',
+      code: async () => {
+        // Get Current Page
+        const currentPage = (await webflow.getCurrentPage()) as Page
+
+        // Get parent page ID
+        const parentPageId = await currentPage.getParentPageId()
+        console.log(parentPageId)
+      },
+    },
+
+    listBranches: {
+      displayName: 'List the branches of a page',
+      code: async () => {
+        // Get Current Page
+        const currentPage = (await webflow.getCurrentPage()) as Page
+
+        // List branches
+        const branches = await currentPage.listBranches()
+        console.log(branches)
+      },
+    }
+  },
 }


### PR DESCRIPTION
Companion examples for the docs work in [webflow/openapi-internal#796](https://github.com/webflow/openapi-internal/pull/796).

Adds a `pageBranching` section to `src/examples/pages.ts` with:

- `getBranchId` — read the branch ID of the current page.
- `getParentPageId` — read the source page ID of a branch.
- `listBranches` — discover all branches for a page.
- `navigateToBranch` — discover branches and switch to the first one.
- `navigateBackToMain` — get parent page ID and switch back to the main page.