### PR TITLE
DEVREL-2827: Add timeout

### DIFF
--- a/src/components/APIExplorer.tsx
+++ b/src/components/APIExplorer.tsx
@@ -53,6 +53,7 @@ const APIExplorer: React.FC<APIExplorerProps> = ({
 }) => {
   const [functionParameters, setFunctionParameters] = useState<ParameterMap>({})
   const [apiOutput, setApiOutput] = useState('')
+  const [isRunning, setIsRunning] = useState(false)
 
   // Fetch function code and parameters
   const { functionCode, parameterNames, parameterTypes, setParameterNames } =
@@ -177,9 +178,12 @@ const APIExplorer: React.FC<APIExplorerProps> = ({
 
       if (funcToExecute) {
         const originalConsole = { ...console }
+        let timedOut = false
+        let timeoutId: ReturnType<typeof setTimeout> | undefined
 
         try {
           setApiOutput('')
+          setIsRunning(true)
 
           const paramValues =
             parameterNames.length > 0
@@ -216,21 +220,42 @@ const APIExplorer: React.FC<APIExplorerProps> = ({
           }
           Object.assign(console, apiConsole)
 
+          timeoutId = setTimeout(() => {
+            timedOut = true
+            Object.assign(console, originalConsole)
+            setApiOutput(
+              (prev) =>
+                prev +
+                '[Timeout] Execution exceeded 5 seconds and was stopped.\n',
+            )
+            setIsRunning(false)
+          }, 5000)
+
           if (typeof funcToExecute === 'function') {
             const result = funcToExecute(...paramValues)
             if (result && typeof result.then === 'function') {
               // Restore console after the async function completes, not before
               result
                 .catch(apiConsole.error)
-                .finally(() => Object.assign(console, originalConsole))
+                .finally(() => {
+                  clearTimeout(timeoutId)
+                  Object.assign(console, originalConsole)
+                  if (!timedOut) setIsRunning(false)
+                })
             } else {
+              clearTimeout(timeoutId)
               Object.assign(console, originalConsole)
+              if (!timedOut) setIsRunning(false)
             }
           } else {
+            clearTimeout(timeoutId)
             Object.assign(console, originalConsole)
+            if (!timedOut) setIsRunning(false)
           }
         } catch (error) {
+          if (timeoutId) clearTimeout(timeoutId)
           Object.assign(console, originalConsole)
+          if (!timedOut) setIsRunning(false)
           console.error('Error executing function:', error)
         }
       }
@@ -321,9 +346,9 @@ const APIExplorer: React.FC<APIExplorerProps> = ({
           <button
             className="button cc-primary"
             onClick={handleFunctionExecution}
-            disabled={!selectedFunctionName}
+            disabled={!selectedFunctionName || isRunning}
           >
-            Run
+            {isRunning ? 'Running...' : 'Run'}
           </button>
           {functionCode && (
             <button

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -235,11 +235,18 @@ const Playground: React.FC<PlaygroundProps> = ({ initialCode }) => {
   // Run user code safely
   const runCode = async (customCode?: string) => {
     setIsRunning(true)
-    setOutput('Running...\n')
+    setOutput('')
     const codeToRun = customCode ?? codeRef.current
+    let timedOut = false
+    const timeoutId = setTimeout(() => {
+      timedOut = true
+      setOutput(
+        (prev) =>
+          prev + '[Timeout] Execution exceeded 5 seconds and was stopped.\n',
+      )
+      setIsRunning(false)
+    }, 5000)
     try {
-      // Clear output and start fresh
-      setOutput('')
       const jsCode = transform(codeToRun, {
         transforms: ['typescript', 'imports'],
         jsxPragma: 'React.createElement',
@@ -251,9 +258,14 @@ const Playground: React.FC<PlaygroundProps> = ({ initialCode }) => {
       const fn = eval(asyncCode)
       await fn((window as any).webflow, safeConsole)
     } catch (err) {
-      safeConsole.error(err)
+      if (!timedOut) {
+        safeConsole.error(err)
+      }
     } finally {
-      setIsRunning(false)
+      clearTimeout(timeoutId)
+      if (!timedOut) {
+        setIsRunning(false)
+      }
     }
   }
 


### PR DESCRIPTION
Some commands can lock up the playground. This adds a 5-second timeout and if the timeout is reached it prints a message about the timeout in the console.

For example, use this code:
```
const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
await sleep(10000)
```
<img width="806" height="632" alt="Screenshot 2026-04-20 at 9 51 57 AM" src="https://github.com/user-attachments/assets/83b943ab-cf31-4acf-91e7-1e3aeea542d1" />
